### PR TITLE
Add more langs to sentiment analysis

### DIFF
--- a/edenai_apis/apis/tenstorrent/info.json
+++ b/edenai_apis/apis/tenstorrent/info.json
@@ -18,7 +18,7 @@
                     "de",
                     "it",
                     "pt",
-                    "ar",
+                    "ar"
                 ],
                 "allow_null_language": true
             },

--- a/edenai_apis/apis/tenstorrent/info.json
+++ b/edenai_apis/apis/tenstorrent/info.json
@@ -12,11 +12,17 @@
         "sentiment_analysis": {
             "constraints": {
                 "languages": [
-                    "en"
+                    "en",
+                    "es",
+                    "fr",
+                    "de",
+                    "it",
+                    "pt",
+                    "ar",
                 ],
                 "allow_null_language": true
             },
-            "version": "v1.0.0"
+            "version": "v1.1.0"
         },
         "question_answer": {
             "version": "v1.0.0"


### PR DESCRIPTION
Bumped version number and added list of langs that testing indicated that the mode did well on. The model should technically support more langs, but we aren't guaranteeing it here. The user anyway doesn't need to specify a language Id hint, so they can use other langs as well